### PR TITLE
Add cuda synchronize code to measure accurate inference time.

### DIFF
--- a/trainers/DepthTrainer.py
+++ b/trainers/DepthTrainer.py
@@ -218,6 +218,7 @@ class KittiDepthTrainer(Trainer):
                 Start_time = time.time()
                 for data in self.dataloaders[s]:
 
+                    torch.cuda.synchronize()
                     start_time = time.time()
 
                     inputs_d, C, labels, item_idxs, inputs_rgb = data
@@ -232,6 +233,7 @@ class KittiDepthTrainer(Trainer):
                     if len(outputs) > 1:
                         outputs = outputs[0]
 
+                    torch.cuda.synchronize()
                     duration = time.time() - start_time
                     times.update(duration / inputs_d.size(0), inputs_d.size(0))
 


### PR DESCRIPTION
Firstly, thank you for opening this good job.

I found an issue about measuring inference time, so submit this PR.
When you measure the inference time in the paper and KITTI benchmark, you may use the below code.
 https://github.com/anglixjtu/msg_chn_wacv20/blob/0d576482982fdb6859bee2ff383c2e7fdd194cad/trainers/DepthTrainer.py#L235

However, as the cuda operations run asynchronously, we should wait for the end of the cuda operations by using `torch.cuda.synchronize()` to estimate the accurate inference time.

In my machine, it takes about 0.0292 sec instead of 0.01 sec.
I recommend you measuring by your machine again and correcting the time logging at the `workspace` directory.